### PR TITLE
ci: add validation workflow for collection integrity

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,16 @@
+name: Validate Design Systems
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate collection integrity
+        run: bash scripts/validate.sh

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# Validate the structural integrity of the awesome-design-md collection.
+#
+# Checks:
+#   1. Every design-md/<site>/ has the 4 required files
+#   2. Every DESIGN.md has 9 numbered sections (## 1. through ## 9.)
+#   3. README badge count matches the actual number of entries
+#   4. Every directory under design-md/ is listed in the README Collection
+#   5. Every entry linked in the README Collection exists on disk
+#   6. Preview HTML files have required structural elements
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DESIGN_DIR="$REPO_ROOT/design-md"
+README="$REPO_ROOT/README.md"
+
+REQUIRED_FILES=("DESIGN.md" "preview.html" "preview-dark.html" "README.md")
+REQUIRED_SECTIONS=(
+  "## 1."
+  "## 2."
+  "## 3."
+  "## 4."
+  "## 5."
+  "## 6."
+  "## 7."
+  "## 8."
+  "## 9."
+)
+
+errors=0
+warnings=0
+
+error() {
+  echo "  ERROR: $1"
+  errors=$((errors + 1))
+}
+
+warn() {
+  echo "  WARN:  $1"
+  warnings=$((warnings + 1))
+}
+
+# ── 1. Entry completeness ────────────────────────────────────────────────────
+
+echo "=== Check 1: Entry completeness ==="
+
+for dir in "$DESIGN_DIR"/*/; do
+  site="$(basename "$dir")"
+  for file in "${REQUIRED_FILES[@]}"; do
+    if [[ ! -f "$dir$file" ]]; then
+      error "$site/ is missing $file"
+    fi
+  done
+done
+
+echo ""
+
+# ── 2. DESIGN.md section schema ──────────────────────────────────────────────
+
+echo "=== Check 2: DESIGN.md section schema ==="
+
+for dir in "$DESIGN_DIR"/*/; do
+  site="$(basename "$dir")"
+  design="$dir/DESIGN.md"
+  [[ ! -f "$design" ]] && continue
+
+  for section in "${REQUIRED_SECTIONS[@]}"; do
+    if ! grep -q "^$section" "$design"; then
+      error "$site/DESIGN.md is missing section heading starting with '$section'"
+    fi
+  done
+done
+
+echo ""
+
+# ── 3. README badge count ────────────────────────────────────────────────────
+
+echo "=== Check 3: README badge count ==="
+
+actual_count=$(find "$DESIGN_DIR" -mindepth 1 -maxdepth 1 -type d | wc -l)
+badge_count=$(grep -oP 'DESIGN\.md%20count-\K[0-9]+' "$README" || echo "0")
+
+if [[ "$badge_count" != "$actual_count" ]]; then
+  error "README badge says $badge_count but there are $actual_count entries on disk"
+else
+  echo "  OK: Badge count ($badge_count) matches directory count"
+fi
+
+echo ""
+
+# ── 4. README ↔ directory sync ────────────────────────────────────────────────
+
+echo "=== Check 4: README <-> directory sync ==="
+
+# Extract site names from Collection bullet links: - [**Name**](...design-md/<site>/...)
+readme_sites=$(grep -oP '^\- \[.*?\]\(.*?/design-md/\K[^/]+' "$README" | sort -u)
+disk_sites=$(ls -1 "$DESIGN_DIR" | sort)
+
+# Directories on disk but not in README
+while IFS= read -r site; do
+  if ! echo "$readme_sites" | grep -qx "$site"; then
+    error "$site/ exists on disk but is not listed in README Collection"
+  fi
+done <<< "$disk_sites"
+
+# Sites in README but no directory on disk
+while IFS= read -r site; do
+  [[ -z "$site" ]] && continue
+  if [[ ! -d "$DESIGN_DIR/$site" ]]; then
+    error "$site is listed in README Collection but has no directory on disk"
+  fi
+done <<< "$readme_sites"
+
+echo ""
+
+# ── 5. Preview HTML structure ─────────────────────────────────────────────────
+
+echo "=== Check 5: Preview HTML structure ==="
+
+for dir in "$DESIGN_DIR"/*/; do
+  site="$(basename "$dir")"
+  for variant in "preview.html" "preview-dark.html"; do
+    html="$dir$variant"
+    [[ ! -f "$html" ]] && continue
+
+    if ! grep -qi '<!DOCTYPE html>' "$html"; then
+      error "$site/$variant is missing <!DOCTYPE html>"
+    fi
+    if ! grep -qi '<html.*lang=' "$html"; then
+      warn "$site/$variant is missing lang attribute on <html>"
+    fi
+    if ! grep -qi 'charset=' "$html"; then
+      error "$site/$variant is missing charset declaration"
+    fi
+    if ! grep -qi 'viewport' "$html"; then
+      warn "$site/$variant is missing viewport meta tag"
+    fi
+  done
+done
+
+echo ""
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo "==========================================="
+echo "  Errors:   $errors"
+echo "  Warnings: $warnings"
+echo "==========================================="
+
+if [[ "$errors" -gt 0 ]]; then
+  echo "FAILED: $errors error(s) found"
+  exit 1
+else
+  echo "PASSED: All checks passed ($warnings warning(s))"
+  exit 0
+fi


### PR DESCRIPTION
## Summary

Closes #93

Adds a GitHub Actions CI workflow that validates the structural integrity of the design system collection on every push to `main` and on every PR. No extra dependencies — just a shell script.

### What it checks

| Check | What it catches |
|-------|----------------|
| **Entry completeness** | Missing `DESIGN.md`, `preview.html`, `preview-dark.html`, or `README.md` in any `design-md/<site>/` directory |
| **DESIGN.md schema** | Missing numbered sections (`## 1.` through `## 9.`) in any DESIGN.md file |
| **README badge count** | Badge count not matching the actual number of entries on disk |
| **README ↔ directory sync** | Directories on disk not listed in README, or README entries with no matching directory |
| **Preview HTML structure** | Missing `<!DOCTYPE html>`, `charset`, `lang` attribute, or `viewport` meta tag |

### Files added

- `.github/workflows/validate.yml` — runs `scripts/validate.sh` on push/PR
- `scripts/validate.sh` — the validation logic (zero dependencies, pure bash)

### Current state

Running the script against `main` today catches 1 existing error:

```
ERROR: README badge says 55 but there are 54 entries on disk
```

This is the known issue from #43. Once that's fixed, the workflow will pass clean and prevent regressions.

## Test plan

- [x] Tested locally: script correctly catches badge count mismatch (known #43)
- [x] Tested edge case: adding an empty directory is flagged (missing files + not in README)
- [x] All 54 existing entries pass completeness and schema checks
- [x] All 108 preview HTML files pass structural checks