### PR TITLE
fix: correct DESIGN.md badge count from 55 to 54

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <div align="center">
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![DESIGN.md Count](https://img.shields.io/badge/DESIGN.md%20count-55-10b981?style=classic)
+![DESIGN.md Count](https://img.shields.io/badge/DESIGN.md%20count-54-10b981?style=classic)
 [![Last Update](https://img.shields.io/github/last-commit/VoltAgent/awesome-design-md?label=Last%20update&style=classic)](https://github.com/VoltAgent/awesome-design-md)
 [![Discord](https://img.shields.io/discord/1361559153780195478.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://s.voltagent.dev/discord)
 


### PR DESCRIPTION
## Problem

The README badge shows **55** DESIGN.md files, but there are only **54** directories in `design-md/`. This causes a visible discrepancy between what the badge advertises and what the collection actually contains.

## Fix

Update the badge URL from `count-55` to `count-54` to match the actual directory count.

Related to the validation check proposed in #93 which would catch this automatically going forward.