### PR TITLE
feat: add Samsung DESIGN.md and preview files

### DIFF
--- a/design-md/samsung/DESIGN.md
+++ b/design-md/samsung/DESIGN.md
@@ -1,0 +1,204 @@
+# Design System Inspiration of Samsung
+
+## 1. Visual Theme & Atmosphere
+
+Samsung’s website presents a bold, structured, and scalable design system built around premium accessibility. The visual language emphasizes strong hierarchy, high contrast, and large architectural content blocks.
+
+The system relies on a dual-typeface strategy:
+
+* **Samsung Sharp Sans** for display and hero content
+* **SamsungOne** for body text and UI
+
+Design is driven by contrast between light and dark sections, with strong use of white, black, and light gray backgrounds, complemented by controlled use of blue accents.
+
+> Note: Samsung proprietary fonts are not publicly available; fallback fonts are used for implementation.
+
+**Key Characteristics:**
+
+* Dual typeface system (display vs UI)
+* Full-width, block-based layout structure
+* Alternating white, light gray, and black sections
+* Pill-shaped primary buttons
+* Strong visual hierarchy with large typography
+* Product-focused imagery with minimal framing
+* Bold inline links with thick underline interactions
+
+---
+
+## 2. Color Palette & Roles
+
+### Primary Brand Colors
+
+* **Samsung Blue (Brand)**: `#1428a0`
+* **Electric Blue (Primary Interactive)**: `#0072ea`
+* **Electric Blue (Secondary Interactive)**: `#2189ff`
+* **Pure Black**: `#000000`
+* **Pure White**: `#ffffff`
+
+### Surfaces & Backgrounds
+
+* **Light Gray**: `#f4f4f4`
+* **Alternate Light Gray**: `#f7f7f7`
+* **Dark Surface 1**: `#1c1c1c`
+* **Dark Surface 2**: `#262626`
+
+### Text Colors
+
+* **Primary Text (Light)**: `#000000`
+* **Secondary Text (Light)**: `#767676`
+* **Primary Text (Dark)**: `#ffffff`
+* **Secondary Text (Dark)**: `#a1a1a1`
+
+### Interactive States
+
+* **Hover (Dark Button)**: `#333333`
+* **Focus Ring**: `2px solid #0072ea`
+
+> Values are approximated based on visual inspection of the live site.
+
+---
+
+## 3. Typography
+
+### Font Families
+
+* **Display**: `Samsung Sharp Sans`, fallback: `Montserrat, Helvetica Neue, Helvetica, Arial, sans-serif`
+* **Body/UI**: `SamsungOne`, fallback: `Inter, Roboto, Helvetica Neue, Helvetica, Arial, sans-serif`
+
+### Type Scale
+
+| Role          | Font       | Size | Weight | Line Height |
+| ------------- | ---------- | ---- | ------ | ----------- |
+| Hero Title    | Sharp Sans | 56px | 700    | 1.15        |
+| Section Title | Sharp Sans | 40px | 700    | 1.20        |
+| Card Title    | Sharp Sans | 24px | 700    | 1.25        |
+| Sub-heading   | SamsungOne | 20px | 600    | 1.30        |
+| Body          | SamsungOne | 16px | 400    | 1.50        |
+| Body Emphasis | SamsungOne | 16px | 600    | 1.50        |
+| Label         | SamsungOne | 14px | 700    | 1.40        |
+| Caption       | SamsungOne | 12px | 400    | 1.40        |
+
+### Principles
+
+* Tight or neutral letter spacing (`0 to -0.02em`)
+* Strong contrast between heading (700) and body (400)
+* High readability and scannability
+
+---
+
+## 4. Components
+
+### Buttons
+
+**Primary (Light Background)**
+
+* Background: `#000000`
+* Text: `#ffffff`
+* Padding: `12px 24px`
+* Radius: `999px`
+* Font: 16px, weight 700
+* Hover: `#333333`
+
+**Primary (Dark Background)**
+
+* Background: `#ffffff`
+* Text: `#000000`
+* Hover: `#e0e0e0`
+
+**Secondary (Outline)**
+
+* Background: `transparent`
+* Border: `2px solid`
+* Radius: `999px`
+
+### Text Links
+
+* Color: `#000000` or `#ffffff`
+* Style: Bold with thick underline on hover
+* Underline:
+
+  * Thickness: `2px`
+  * Offset: `4px`
+
+---
+
+### Cards
+
+* Background: `#ffffff` or `#f4f4f4`
+* Dark Mode: `#1c1c1c`
+* Radius: `16px – 24px`
+* Shadow: `0px 8px 24px rgba(0,0,0,0.08)` or none
+
+---
+
+### Navigation
+
+* Height: `64px – 80px`
+* Background: `#ffffff`
+* Border: `1px solid #ebebeb`
+* Style: Minimal, no heavy shadows
+
+---
+
+## 5. Layout & Spacing
+
+* Block-based sectioning using color contrast
+* Large internal spacing: `40px – 64px`
+* Full-width sections with clear separation
+* Generous whitespace around key elements
+
+### Border Radius Scale
+
+* Small UI: `8px`
+* Cards: `16px – 24px`
+* Buttons: `999px`
+
+---
+
+## 6. Depth & Elevation
+
+Depth is achieved through:
+
+1. Color contrast
+2. Border radius
+3. Minimal shadow usage
+
+Samsung favors a **flat-but-separated** design approach.
+
+---
+
+## 7. Do’s and Don’ts
+
+### Do
+
+* Use strong contrast between sections
+* Emphasize primary CTAs with pill buttons
+* Keep layouts clean and spacious
+* Use bold typography for hierarchy
+
+### Don’t
+
+* Overuse brand blue
+* Use small border radii on large components
+* Add unnecessary visual clutter in hero sections
+
+---
+
+## 8. Agent Prompt Guide
+
+### Quick Reference
+
+* Background: `#f4f4f4` or `#000000`
+* CTA (Light): black pill button
+* CTA (Dark): white pill button
+* Card: `#ffffff` or `#1c1c1c`
+* Secondary Text: `#767676`
+* Accent: `#0072ea`
+
+---
+
+### Example Prompts
+
+* "Create a Samsung-style hero section with a light gray background (#f4f4f4), a bold 56px heading, and a black pill CTA."
+* "Design a product grid with white cards, 24px radius, and bold headings."
+* "Build a dark section with black background, white text, and a white pill CTA."

--- a/design-md/samsung/README.md
+++ b/design-md/samsung/README.md
@@ -1,0 +1,23 @@
+# Samsung Inspired Design System
+
+[DESIGN.md](https://github.com/VoltAgent/awesome-design-md/blob/main/design-md/samsung/DESIGN.md) extracted and analyzed from the public [Samsung](https://samsung.com/) website. This is not the official design system. Colors, typography, and specific spacing rules have been approximated for web implementation based on current visual trends on Samsung's digital platforms.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `DESIGN.md` | Complete design system documentation (8 sections) |
+| `preview.html` | Interactive design token catalog (light) |
+| `preview-dark.html` | Interactive design token catalog (dark) |
+
+Use [DESIGN.md](https://github.com/VoltAgent/awesome-design-md/blob/main/design-md/samsung/DESIGN.md) as a structural reference for AI agents (Claude, Cursor, VoltAgent) to generate user interfaces that mimic the bold, high-contrast, structural design language of Samsung.
+
+## Preview
+
+A sample demonstration page built with DESIGN.md showing the actual colors, typography, buttons, structural cards, and spacing values in action.
+
+### Dark Mode
+![Samsung Design System — Dark Mode](https://pub-2e4ecbcbc9b24e7b93f1a6ab5b2bc71f.r2.dev/designs/samsung/preview-dark-screenshot.png)
+
+### Light Mode
+![Samsung Design System — Light Mode](https://pub-2e4ecbcbc9b24e7b93f1a6ab5b2bc71f.r2.dev/designs/samsung/preview-screenshot.png)

--- a/design-md/samsung/preview-dark.html
+++ b/design-md/samsung/preview-dark.html
@@ -1,0 +1,285 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Design System Preview: Samsung (Dark)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --white: #000000;
+    --black: #ffffff;
+    --light-gray: #141414;
+    --electric-blue: #2189ff;
+    --brand-blue: #1428a0;
+    --text-primary: #ffffff;
+    --text-sec: #a1a1a1;
+    --text-ter: #767676;
+    --card-bg-light: #1c1c1c;
+    --card-bg-alt: #1c1c1c;
+    --font-display: 'Samsung Sharp Sans', 'Montserrat', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    --font-text: 'SamsungOne', 'Inter', 'Roboto', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    --radius-pill: 999px;
+    --radius-card: 20px;
+    --radius-ui: 8px;
+    --shadow-soft: 0px 8px 24px rgba(0,0,0,0.5);
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: var(--white);
+    color: var(--text-primary);
+    font-family: var(--font-text);
+    font-size: 16px; font-weight: 400; line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* NAV */
+  .nav {
+    position: sticky; top: 0; z-index: 100;
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0 40px; height: 72px;
+    background: var(--white);
+    border-bottom: 1px solid #333333;
+  }
+  .nav-brand { font-family: var(--font-display); font-size: 20px; font-weight: 700; color: var(--black); text-decoration: none; letter-spacing: -0.5px; text-transform: uppercase; }
+  .nav-links { display: flex; gap: 32px; list-style: none; }
+  .nav-links a { font-size: 14px; font-weight: 600; color: var(--black); text-decoration: none; transition: color 0.2s; position: relative; }
+  .nav-links a:hover::after { content: ''; position: absolute; bottom: -26px; left: 0; width: 100%; height: 2px; background: var(--black); }
+  .nav-cta {
+    display: inline-block; background: var(--black); color: var(--white);
+    padding: 8px 20px; border-radius: var(--radius-pill); font-size: 14px; font-weight: 700;
+    text-decoration: none; transition: background 0.2s;
+  }
+  .nav-cta:hover { background: #cccccc; color: #000; }
+
+  /* DARK BADGE */
+  .dark-badge {
+    position: fixed; top: 16px; right: 16px; z-index: 200;
+    background: #ffffff; color: #000000;
+    font-size: 11px; font-weight: 700; padding: 6px 12px; border-radius: 8px;
+    font-family: var(--font-text); text-transform: uppercase;
+  }
+
+  /* HERO */
+  .hero { padding: 100px 40px; text-align: center; background: var(--light-gray); }
+  .hero h1 {
+    font-family: var(--font-display);
+    font-size: 56px; font-weight: 700; line-height: 1.15;
+    color: var(--black); margin-bottom: 24px; letter-spacing: -0.5px;
+  }
+  .hero p { font-size: 20px; font-weight: 600; line-height: 1.3; color: var(--text-sec); max-width: 650px; margin: 0 auto 40px; }
+  .hero-buttons { display: flex; gap: 16px; justify-content: center; flex-wrap: wrap; }
+  .btn-primary {
+    display: inline-block; background: var(--black); color: var(--white);
+    padding: 12px 28px; border-radius: var(--radius-pill); border: none;
+    font-family: var(--font-text); font-size: 16px; font-weight: 700;
+    text-decoration: none; cursor: pointer; transition: background 0.2s;
+  }
+  .btn-primary:hover { background: #cccccc; color: #000; }
+  .btn-outline {
+    display: inline-block; background: transparent; color: var(--black);
+    padding: 10px 26px; border-radius: var(--radius-pill);
+    border: 2px solid var(--black);
+    font-family: var(--font-text); font-size: 16px; font-weight: 700;
+    text-decoration: none; cursor: pointer; transition: background 0.2s, color 0.2s;
+  }
+  .btn-outline:hover { background: var(--black); color: var(--white); }
+
+  /* SECTIONS */
+  .section { padding: 80px 40px; max-width: 1200px; margin: 0 auto; }
+  .section-label { font-family: var(--font-text); font-size: 14px; font-weight: 700; color: var(--electric-blue); text-transform: uppercase; margin-bottom: 12px; letter-spacing: 1px; }
+  .section-title { font-family: var(--font-display); font-size: 40px; font-weight: 700; line-height: 1.20; margin-bottom: 40px; letter-spacing: -0.5px; color: var(--black); }
+
+  /* FULL WIDTH BLOCKS */
+  .bg-black { background: #ffffff; color: #000000; }
+  .bg-black .section-title, .bg-black .text-styled { color: #000000; }
+  .bg-black .text-sec { color: #555555; }
+  
+  .bg-gray { background: var(--light-gray); }
+
+  /* COLORS */
+  .color-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 16px; margin-bottom: 32px; }
+  .color-swatch { border-radius: var(--radius-ui); overflow: hidden; background: #1c1c1c; box-shadow: 0 0 0 1px #333333; }
+  .color-swatch-block { height: 80px; width: 100%; border-bottom: 1px solid #333333; }
+  .color-swatch-info { padding: 12px 16px; }
+  .color-swatch-name { font-size: 14px; font-weight: 700; margin-bottom: 4px; color: var(--black); }
+  .color-swatch-hex { font-size: 12px; color: var(--text-sec); font-family: monospace; }
+  .color-group-label { font-size: 18px; font-weight: 700; margin: 32px 0 16px; border-bottom: 2px solid #333; padding-bottom: 8px; display: inline-block; color: var(--black); }
+
+  /* TYPOGRAPHY */
+  .type-sample { margin-bottom: 32px; padding-bottom: 24px; border-bottom: 1px solid #333333; }
+  .type-sample:last-child { border-bottom: none; }
+  .type-meta { font-family: monospace; font-size: 12px; font-weight: 400; color: var(--text-sec); margin-top: 12px; }
+
+  /* BUTTONS */
+  .button-row { display: flex; gap: 24px; flex-wrap: wrap; align-items: center; }
+  .button-item { display: flex; flex-direction: column; align-items: center; gap: 12px; }
+  .button-label { font-size: 12px; font-weight: 700; color: var(--text-sec); text-transform: uppercase; }
+  .text-link {
+    font-size: 16px; font-weight: 700; color: var(--black); text-decoration: none; display: inline-flex; align-items: center; gap: 4px; position: relative;
+  }
+  .text-link::after { content: ''; position: absolute; bottom: -2px; left: 0; width: 100%; height: 2px; background: var(--black); transition: height 0.2s, bottom 0.2s; }
+  .text-link:hover::after { height: 4px; bottom: -4px; }
+  
+  .text-link-blue { color: var(--electric-blue); }
+  .text-link-blue::after { background: var(--electric-blue); }
+
+  /* CARDS */
+  .card-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 24px; }
+  .card { background: var(--card-bg-light); border-radius: var(--radius-card); padding: 48px 32px; transition: transform 0.3s, box-shadow 0.3s; display: flex; flex-direction: column; align-items: center; border: 1px solid #333; text-align: center; }
+  .card:hover { transform: translateY(-4px); box-shadow: var(--shadow-soft); border-color: #555; }
+  .card h3 { font-family: var(--font-display); font-size: 24px; font-weight: 700; line-height: 1.25; margin-bottom: 12px; color: var(--black); }
+  .card p { font-size: 16px; color: var(--text-sec); margin-bottom: 24px; }
+
+  /* FORMS */
+  .form-group { margin-bottom: 24px; max-width: 480px; }
+  .form-label { display: block; font-size: 14px; font-weight: 700; color: var(--black); margin-bottom: 8px; }
+  .form-input {
+    width: 100%; background: #141414; color: var(--black);
+    border: 1px solid #333; padding: 14px 16px; border-radius: var(--radius-ui);
+    font-family: var(--font-text); font-size: 16px; outline: none; transition: border-color 0.2s, background 0.2s;
+  }
+  .form-input:focus { border-color: var(--electric-blue); box-shadow: 0 0 0 1px var(--electric-blue); }
+  
+  .footer { padding: 40px; text-align: center; background: var(--white); border-top: 1px solid #333333; font-size: 14px; color: var(--text-sec); }
+</style>
+</head>
+<body>
+
+<div class="dark-badge">Dark Mode</div>
+
+<nav class="nav">
+  <a class="nav-brand" href="#">Samsung UI</a>
+  <ul class="nav-links">
+    <li><a href="#colors">Colors</a></li>
+    <li><a href="#typography">Typography</a></li>
+    <li><a href="#components">Components</a></li>
+    <li><a href="#cards">Structural</a></li>
+  </ul>
+  <a class="nav-cta" href="#">Pre-order</a>
+</nav>
+
+<section class="hero">
+  <div class="section-label" style="color:var(--text-sec); margin-bottom:20px;">Design System Overview</div>
+  <h1>Bold, expansive, and<br>highly structured.</h1>
+  <p>A design token preview approximating the dynamic, high-contrast, block-based UI architecture used by Samsung.</p>
+  <div class="hero-buttons">
+    <a class="btn-primary" href="#">Explore Guidelines</a>
+    <a class="btn-outline" href="#">View Components</a>
+  </div>
+</section>
+
+<section class="section" id="colors">
+  <div class="section-label">Foundation</div>
+  <h2 class="section-title">Color System</h2>
+
+  <div class="color-group-label">Core Neutrals</div>
+  <div class="color-grid">
+    <div class="color-swatch"><div class="color-swatch-block" style="background:#000000"></div><div class="color-swatch-info"><div class="color-swatch-name">Pure Black</div><div class="color-swatch-hex">#000000</div></div></div>
+    <div class="color-swatch"><div class="color-swatch-block" style="background:#ffffff"></div><div class="color-swatch-info"><div class="color-swatch-name">Pure White</div><div class="color-swatch-hex">#ffffff</div></div></div>
+    <div class="color-swatch"><div class="color-swatch-block" style="background:#141414"></div><div class="color-swatch-info"><div class="color-swatch-name">Dark Gray</div><div class="color-swatch-hex">#141414</div></div></div>
+  </div>
+
+  <div class="color-group-label">Brand & Accent</div>
+  <div class="color-grid">
+    <div class="color-swatch"><div class="color-swatch-block" style="background:var(--electric-blue)"></div><div class="color-swatch-info"><div class="color-swatch-name">Electric Blue (UI)</div><div class="color-swatch-hex">#2189ff</div></div></div>
+  </div>
+
+  <div class="color-group-label">Text</div>
+  <div class="color-grid">
+    <div class="color-swatch"><div class="color-swatch-block" style="background:var(--text-sec)"></div><div class="color-swatch-info"><div class="color-swatch-name">Text Secondary</div><div class="color-swatch-hex">#a1a1a1</div></div></div>
+  </div>
+</section>
+
+<section class="section bg-gray" id="typography">
+  <div class="section-label">Typography</div>
+  <h2 class="section-title">Scale & Hierarchy</h2>
+
+  <div class="type-sample"><div style="font-family:var(--font-display); font-size:56px; font-weight:700; line-height:1.15; letter-spacing:-0.5px; color:var(--black);">Display Hero 56</div><div class="type-meta">Samsung Sharp Sans (Montserrat) - 56px / 700 / 1.15</div></div>
+  <div class="type-sample"><div style="font-family:var(--font-display); font-size:40px; font-weight:700; line-height:1.20; letter-spacing:-0.5px; color:var(--black);">Section Title 40</div><div class="type-meta">Samsung Sharp Sans (Montserrat) - 40px / 700 / 1.20</div></div>
+  <div class="type-sample"><div style="font-family:var(--font-display); font-size:24px; font-weight:700; line-height:1.25; color:var(--black);">Card Title 24</div><div class="type-meta">Samsung Sharp Sans (Montserrat) - 24px / 700 / 1.25</div></div>
+  <div class="type-sample"><div style="font-family:var(--font-text); font-size:20px; font-weight:600; line-height:1.30; color:var(--text-sec);">Sub-heading 20</div><div class="type-meta">SamsungOne (Inter) - 20px / 600 / 1.30</div></div>
+  <div class="type-sample"><div style="font-family:var(--font-text); font-size:16px; font-weight:400; line-height:1.50; color:var(--black);">Body text 16. Designed to establish a balance between structural strength and seamless readability across all digital touchpoints.</div><div class="type-meta">SamsungOne (Inter) - 16px / 400 / 1.50</div></div>
+  <div class="type-sample"><div style="font-family:var(--font-text); font-size:14px; font-weight:700; line-height:1.40; color:var(--black);">LABEL & BUTTON 14</div><div class="type-meta">SamsungOne (Inter) - 14px / 700 / 1.40</div></div>
+</section>
+
+<section class="section" id="components">
+  <div class="section-label">Interactive</div>
+  <h2 class="section-title">Buttons & CTAs</h2>
+  
+  <div class="button-row" style="margin-bottom:48px;">
+    <div class="button-item"><button class="btn-primary">Buy now</button><div class="button-label">Primary White</div></div>
+    <div class="button-item"><button class="btn-outline">Learn more</button><div class="button-label">Outline</div></div>
+    <div class="button-item"><a href="#" class="text-link">Learn more <span>></span></a><div class="button-label">Text Link (Hover Bold Underline)</div></div>
+    <div class="button-item"><a href="#" class="text-link text-link-blue">See offers <span>></span></a><div class="button-label">Text Link (Blue)</div></div>
+  </div>
+
+  <h2 class="section-title" style="margin-top: 64px;">Inputs</h2>
+  <div class="form-group">
+    <label class="form-label">Email Address</label>
+    <input type="email" class="form-input" placeholder="Enter your email">
+  </div>
+</section>
+
+<div class="bg-black">
+  <section class="section" id="light-context">
+    <div class="section-label" style="color:#555555;">Contrast</div>
+    <h2 class="section-title">Light Mode Sections</h2>
+    
+    <div class="button-row" style="margin-bottom: 48px;">
+      <div class="button-item">
+        <button class="btn-primary" style="background:#000000; color:#ffffff;">Pre-order</button>
+        <div class="button-label" style="color:#555555;">Primary Black</div>
+      </div>
+      <div class="button-item">
+        <a href="#" class="text-link" style="color:#000000;">Watch film <span>></span></a>
+        <div class="button-label" style="color:#555555;">Light Context Link</div>
+      </div>
+    </div>
+    
+    <div class="card-grid">
+      <div class="card" style="background:#f4f4f4; border:none; box-shadow:none;">
+        <h3 style="color:#000000;">Galaxy Core</h3>
+        <p style="color:#555555;">Experience the ultimate performance with advanced chipset technologies.</p>
+        <button class="btn-primary" style="background:#000000; color:#ffffff; margin-top:auto;">Discover</button>
+      </div>
+      <div class="card" style="background:#f4f4f4; border:none; box-shadow:none;">
+        <h3 style="color:#000000;">SmartThings</h3>
+        <p style="color:#555555;">Connect your entire home ecosystem seamlessly.</p>
+        <a href="#" class="text-link" style="color:#000000; margin-top:auto;">Learn more <span>></span></a>
+      </div>
+    </div>
+  </section>
+</div>
+
+<section class="section bg-gray" id="cards">
+  <div class="section-label">Structural</div>
+  <h2 class="section-title">Card Grids (20px Radius)</h2>
+  
+  <div class="card-grid">
+    <div class="card">
+      <h3>Smartphones</h3>
+      <p>The iconic series that redefines what a mobile device can do.</p>
+      <button class="btn-primary" style="margin-top:auto;">Shop</button>
+    </div>
+    <div class="card">
+      <h3>TV & AV</h3>
+      <p>Breathtaking visual experiences powered by Neo QLED technology.</p>
+      <button class="btn-primary" style="margin-top:auto;">Shop</button>
+    </div>
+    <div class="card">
+      <h3>Appliances</h3>
+      <p>Intelligent home solutions designed for your lifestyle.</p>
+      <button class="btn-primary" style="margin-top:auto;">Shop</button>
+    </div>
+  </div>
+</section>
+
+<footer class="footer">
+  Inspired by Samsung's digital design language. Created for awesome-design-md.
+</footer>
+
+</body>
+</html>

--- a/design-md/samsung/preview.html
+++ b/design-md/samsung/preview.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Design System Preview: Samsung (Light)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --black: #000000;
+    --white: #ffffff;
+    --light-gray: #f4f4f4;
+    --electric-blue: #0072ea;
+    --brand-blue: #1428a0;
+    --text-primary: #000000;
+    --text-sec: #767676;
+    --text-ter: #a1a1a1;
+    --card-bg-light: #ffffff;
+    --card-bg-alt: #f4f4f4;
+    --font-display: 'Samsung Sharp Sans', 'Montserrat', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    --font-text: 'SamsungOne', 'Inter', 'Roboto', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    --radius-pill: 999px;
+    --radius-card: 20px;
+    --radius-ui: 8px;
+    --shadow-soft: 0px 8px 24px rgba(0,0,0,0.06);
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: var(--white);
+    color: var(--text-primary);
+    font-family: var(--font-text);
+    font-size: 16px; font-weight: 400; line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* NAV */
+  .nav {
+    position: sticky; top: 0; z-index: 100;
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0 40px; height: 72px;
+    background: var(--white);
+    border-bottom: 1px solid #ebebeb;
+  }
+  .nav-brand { font-family: var(--font-display); font-size: 20px; font-weight: 700; color: var(--black); text-decoration: none; letter-spacing: -0.5px; text-transform: uppercase; }
+  .nav-links { display: flex; gap: 32px; list-style: none; }
+  .nav-links a { font-size: 14px; font-weight: 600; color: var(--black); text-decoration: none; transition: color 0.2s; position: relative; }
+  .nav-links a:hover::after { content: ''; position: absolute; bottom: -26px; left: 0; width: 100%; height: 2px; background: var(--black); }
+  .nav-cta {
+    display: inline-block; background: var(--black); color: var(--white);
+    padding: 8px 20px; border-radius: var(--radius-pill); font-size: 14px; font-weight: 700;
+    text-decoration: none; transition: background 0.2s;
+  }
+  .nav-cta:hover { background: #333333; }
+
+  /* HERO */
+  .hero { padding: 100px 40px; text-align: center; background: var(--light-gray); }
+  .hero h1 {
+    font-family: var(--font-display);
+    font-size: 56px; font-weight: 700; line-height: 1.15;
+    color: var(--black); margin-bottom: 24px; letter-spacing: -0.5px;
+  }
+  .hero p { font-size: 20px; font-weight: 600; line-height: 1.3; color: var(--text-sec); max-width: 650px; margin: 0 auto 40px; }
+  .hero-buttons { display: flex; gap: 16px; justify-content: center; flex-wrap: wrap; }
+  .btn-primary {
+    display: inline-block; background: var(--black); color: var(--white);
+    padding: 12px 28px; border-radius: var(--radius-pill); border: none;
+    font-family: var(--font-text); font-size: 16px; font-weight: 700;
+    text-decoration: none; cursor: pointer; transition: background 0.2s;
+  }
+  .btn-primary:hover { background: #333333; }
+  .btn-outline {
+    display: inline-block; background: transparent; color: var(--black);
+    padding: 10px 26px; border-radius: var(--radius-pill);
+    border: 2px solid var(--black);
+    font-family: var(--font-text); font-size: 16px; font-weight: 700;
+    text-decoration: none; cursor: pointer; transition: background 0.2s, color 0.2s;
+  }
+  .btn-outline:hover { background: var(--black); color: var(--white); }
+
+  /* SECTIONS */
+  .section { padding: 80px 40px; max-width: 1200px; margin: 0 auto; }
+  .section-label { font-family: var(--font-text); font-size: 14px; font-weight: 700; color: var(--electric-blue); text-transform: uppercase; margin-bottom: 12px; letter-spacing: 1px; }
+  .section-title { font-family: var(--font-display); font-size: 40px; font-weight: 700; line-height: 1.20; margin-bottom: 40px; letter-spacing: -0.5px; }
+
+  /* FULL WIDTH BLOCKS */
+  .bg-black { background: var(--black); color: var(--white); }
+  .bg-black .section-title, .bg-black .text-styled { color: var(--white); }
+  .bg-black .text-sec { color: var(--text-ter); }
+  
+  .bg-gray { background: var(--light-gray); }
+
+  /* COLORS */
+  .color-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 16px; margin-bottom: 32px; }
+  .color-swatch { border-radius: var(--radius-ui); overflow: hidden; background: #ffffff; box-shadow: 0 0 0 1px #ebebeb; }
+  .color-swatch-block { height: 80px; width: 100%; border-bottom: 1px solid #ebebeb; }
+  .color-swatch-info { padding: 12px 16px; }
+  .color-swatch-name { font-size: 14px; font-weight: 700; margin-bottom: 4px; color: var(--black); }
+  .color-swatch-hex { font-size: 12px; color: var(--text-sec); font-family: monospace; }
+  .color-group-label { font-size: 18px; font-weight: 700; margin: 32px 0 16px; border-bottom: 2px solid var(--black); padding-bottom: 8px; display: inline-block; }
+
+  /* TYPOGRAPHY */
+  .type-sample { margin-bottom: 32px; padding-bottom: 24px; border-bottom: 1px solid #ebebeb; }
+  .type-sample:last-child { border-bottom: none; }
+  .type-meta { font-family: monospace; font-size: 12px; font-weight: 400; color: var(--text-sec); margin-top: 12px; }
+
+  /* BUTTONS */
+  .button-row { display: flex; gap: 24px; flex-wrap: wrap; align-items: center; }
+  .button-item { display: flex; flex-direction: column; align-items: center; gap: 12px; }
+  .button-label { font-size: 12px; font-weight: 700; color: var(--text-sec); text-transform: uppercase; }
+  .text-link {
+    font-size: 16px; font-weight: 700; color: var(--black); text-decoration: none; display: inline-flex; align-items: center; gap: 4px; position: relative;
+  }
+  .text-link::after { content: ''; position: absolute; bottom: -2px; left: 0; width: 100%; height: 2px; background: var(--black); transition: height 0.2s, bottom 0.2s; }
+  .text-link:hover::after { height: 4px; bottom: -4px; }
+  
+  .text-link-blue { color: var(--electric-blue); }
+  .text-link-blue::after { background: var(--electric-blue); }
+
+  /* CARDS */
+  .card-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 24px; }
+  .card { background: var(--card-bg-light); border-radius: var(--radius-card); padding: 48px 32px; transition: transform 0.3s, box-shadow 0.3s; display: flex; flex-direction: column; align-items: center; text-align: center; }
+  .card:hover { transform: translateY(-4px); box-shadow: var(--shadow-soft); }
+  .card h3 { font-family: var(--font-display); font-size: 24px; font-weight: 700; line-height: 1.25; margin-bottom: 12px; }
+  .card p { font-size: 16px; color: var(--text-sec); margin-bottom: 24px; }
+  
+  .card-gray { background: var(--card-bg-alt); }
+
+  /* FORMS */
+  .form-group { margin-bottom: 24px; max-width: 480px; }
+  .form-label { display: block; font-size: 14px; font-weight: 700; color: var(--black); margin-bottom: 8px; }
+  .form-input {
+    width: 100%; background: var(--card-bg-alt); color: var(--black);
+    border: 1px solid transparent; padding: 14px 16px; border-radius: var(--radius-ui);
+    font-family: var(--font-text); font-size: 16px; outline: none; transition: border-color 0.2s, background 0.2s;
+  }
+  .form-input:focus { border-color: var(--electric-blue); background: var(--white); box-shadow: 0 0 0 1px var(--electric-blue); }
+  
+  /* RADIUS */
+  .radius-row { display: flex; gap: 24px; flex-wrap: wrap; }
+  .radius-item { text-align: center; }
+  .radius-box { width: 80px; height: 80px; background: var(--black); margin-bottom: 12px; }
+  
+  .footer { padding: 40px; text-align: center; background: var(--white); border-top: 1px solid #ebebeb; font-size: 14px; color: var(--text-sec); }
+</style>
+</head>
+<body>
+
+<nav class="nav">
+  <a class="nav-brand" href="#">Samsung UI</a>
+  <ul class="nav-links">
+    <li><a href="#colors">Colors</a></li>
+    <li><a href="#typography">Typography</a></li>
+    <li><a href="#components">Components</a></li>
+    <li><a href="#cards">Structural</a></li>
+  </ul>
+  <a class="nav-cta" href="#">Pre-order</a>
+</nav>
+
+<section class="hero">
+  <div class="section-label" style="color:var(--text-sec); margin-bottom:20px;">Design System Overview</div>
+  <h1>Bold, expansive, and<br>highly structured.</h1>
+  <p>A design token preview approximating the dynamic, high-contrast, block-based UI architecture used by Samsung.</p>
+  <div class="hero-buttons">
+    <a class="btn-primary" href="#">Explore Guidelines</a>
+    <a class="btn-outline" href="#">View Components</a>
+  </div>
+</section>
+
+<section class="section" id="colors">
+  <div class="section-label">Foundation</div>
+  <h2 class="section-title">Color System</h2>
+
+  <div class="color-group-label">Core Neutrals</div>
+  <div class="color-grid">
+    <div class="color-swatch"><div class="color-swatch-block" style="background:var(--black)"></div><div class="color-swatch-info"><div class="color-swatch-name">Pure Black</div><div class="color-swatch-hex">#000000</div></div></div>
+    <div class="color-swatch"><div class="color-swatch-block" style="background:var(--white)"></div><div class="color-swatch-info"><div class="color-swatch-name">Pure White</div><div class="color-swatch-hex">#ffffff</div></div></div>
+    <div class="color-swatch"><div class="color-swatch-block" style="background:var(--light-gray)"></div><div class="color-swatch-info"><div class="color-swatch-name">Light Gray</div><div class="color-swatch-hex">#f4f4f4</div></div></div>
+  </div>
+
+  <div class="color-group-label">Brand & Accent</div>
+  <div class="color-grid">
+    <div class="color-swatch"><div class="color-swatch-block" style="background:var(--electric-blue)"></div><div class="color-swatch-info"><div class="color-swatch-name">Electric Blue (UI)</div><div class="color-swatch-hex">#0072ea</div></div></div>
+    <div class="color-swatch"><div class="color-swatch-block" style="background:var(--brand-blue)"></div><div class="color-swatch-info"><div class="color-swatch-name">Samsung Blue</div><div class="color-swatch-hex">#1428a0</div></div></div>
+  </div>
+
+  <div class="color-group-label">Text</div>
+  <div class="color-grid">
+    <div class="color-swatch"><div class="color-swatch-block" style="background:var(--text-sec)"></div><div class="color-swatch-info"><div class="color-swatch-name">Text Secondary</div><div class="color-swatch-hex">#767676</div></div></div>
+  </div>
+</section>
+
+<section class="section bg-gray" id="typography">
+  <div class="section-label">Typography</div>
+  <h2 class="section-title">Scale & Hierarchy</h2>
+
+  <div class="type-sample"><div style="font-family:var(--font-display); font-size:56px; font-weight:700; line-height:1.15; letter-spacing:-0.5px;">Display Hero 56</div><div class="type-meta">Samsung Sharp Sans (Montserrat) - 56px / 700 / 1.15</div></div>
+  <div class="type-sample"><div style="font-family:var(--font-display); font-size:40px; font-weight:700; line-height:1.20; letter-spacing:-0.5px;">Section Title 40</div><div class="type-meta">Samsung Sharp Sans (Montserrat) - 40px / 700 / 1.20</div></div>
+  <div class="type-sample"><div style="font-family:var(--font-display); font-size:24px; font-weight:700; line-height:1.25;">Card Title 24</div><div class="type-meta">Samsung Sharp Sans (Montserrat) - 24px / 700 / 1.25</div></div>
+  <div class="type-sample"><div style="font-family:var(--font-text); font-size:20px; font-weight:600; line-height:1.30; color:var(--text-sec);">Sub-heading 20</div><div class="type-meta">SamsungOne (Inter) - 20px / 600 / 1.30</div></div>
+  <div class="type-sample"><div style="font-family:var(--font-text); font-size:16px; font-weight:400; line-height:1.50;">Body text 16. Designed to establish a balance between structural strength and seamless readability across all digital touchpoints.</div><div class="type-meta">SamsungOne (Inter) - 16px / 400 / 1.50</div></div>
+  <div class="type-sample"><div style="font-family:var(--font-text); font-size:14px; font-weight:700; line-height:1.40;">LABEL & BUTTON 14</div><div class="type-meta">SamsungOne (Inter) - 14px / 700 / 1.40</div></div>
+</section>
+
+<section class="section" id="components">
+  <div class="section-label">Interactive</div>
+  <h2 class="section-title">Buttons & CTAs</h2>
+  
+  <div class="button-row" style="margin-bottom:48px;">
+    <div class="button-item"><button class="btn-primary">Buy now</button><div class="button-label">Primary Black</div></div>
+    <div class="button-item"><button class="btn-outline">Learn more</button><div class="button-label">Outline</div></div>
+    <div class="button-item"><a href="#" class="text-link">Learn more <span>></span></a><div class="button-label">Text Link (Hover Bold Underline)</div></div>
+    <div class="button-item"><a href="#" class="text-link text-link-blue">See offers <span>></span></a><div class="button-label">Text Link (Blue)</div></div>
+  </div>
+
+  <h2 class="section-title" style="margin-top: 64px;">Inputs</h2>
+  <div class="form-group">
+    <label class="form-label">Email Address</label>
+    <input type="email" class="form-input" placeholder="Enter your email">
+  </div>
+</section>
+
+<div class="bg-black">
+  <section class="section" id="dark-context">
+    <div class="section-label" style="color:var(--text-ter);">Immersive</div>
+    <h2 class="section-title">Dark Mode & Elevations</h2>
+    
+    <div class="button-row" style="margin-bottom: 48px;">
+      <div class="button-item">
+        <button class="btn-primary" style="background:var(--white); color:var(--black);">Pre-order</button>
+        <div class="button-label" style="color:var(--text-ter);">Primary White</div>
+      </div>
+      <div class="button-item">
+        <a href="#" class="text-link" style="color:var(--white);">Watch film <span>></span></a>
+        <div class="button-label" style="color:var(--text-ter);">Dark Context Link</div>
+      </div>
+    </div>
+    
+    <div class="card-grid">
+      <div class="card" style="background:#1c1c1c; border: 1px solid #333;">
+        <h3 style="color:var(--white);">Galaxy Core</h3>
+        <p style="color:var(--text-ter);">Experience the ultimate performance with advanced chipset technologies.</p>
+        <button class="btn-primary" style="background:var(--white); color:var(--black); margin-top:auto;">Discover</button>
+      </div>
+      <div class="card" style="background:#1c1c1c; border: 1px solid #333;">
+        <h3 style="color:var(--white);">SmartThings</h3>
+        <p style="color:var(--text-ter);">Connect your entire home ecosystem seamlessly.</p>
+        <a href="#" class="text-link" style="color:var(--white); margin-top:auto;">Learn more <span>></span></a>
+      </div>
+    </div>
+  </section>
+</div>
+
+<section class="section bg-gray" id="cards">
+  <div class="section-label">Structural</div>
+  <h2 class="section-title">Card Grids (20px Radius)</h2>
+  
+  <div class="card-grid">
+    <div class="card card-gray" style="background:var(--white);">
+      <h3>Smartphones</h3>
+      <p>The iconic series that redefines what a mobile device can do.</p>
+      <button class="btn-primary" style="margin-top:auto;">Shop</button>
+    </div>
+    <div class="card card-gray" style="background:var(--white);">
+      <h3>TV & AV</h3>
+      <p>Breathtaking visual experiences powered by Neo QLED technology.</p>
+      <button class="btn-primary" style="margin-top:auto;">Shop</button>
+    </div>
+    <div class="card card-gray" style="background:var(--white);">
+      <h3>Appliances</h3>
+      <p>Intelligent home solutions designed for your lifestyle.</p>
+      <button class="btn-primary" style="margin-top:auto;">Shop</button>
+    </div>
+  </div>
+</section>
+
+<footer class="footer">
+  Inspired by Samsung's digital design language. Created for awesome-design-md.
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
### Add Samsung.com DESIGN.md

Hi 👋

This PR adds a `DESIGN.md` for https://www.samsung.com/, capturing its design system in a structured and reusable format.

Samsung’s design stands out for its strong contrast-driven layout, dual typography system (Sharp Sans + SamsungOne), and consistent use of full-width sections with clear visual hierarchy. The goal of this file is to translate those patterns into a format that’s easy for developers and AI agents to understand and reuse.

#### What’s included

* Color system (light/dark surfaces, interactive colors)
* Typography hierarchy with fallbacks
* Component styles (buttons, cards, navigation)
* Layout and spacing principles
* Agent prompt guide for practical usage

Most values are derived from visual inspection of the live site and aim to stay as close as possible to real-world usage.

Let me know if you’d like any refinements or corrections 👍

Closes #321 
