### PR TITLE
feat: add Claude Code skill for one-command DESIGN.md install

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,35 @@ Each site includes:
 1. Copy a site's `DESIGN.md` into your project root
 2. Tell your AI agent to use it.
 
+### Claude Code Skill (One-Command Install)
+
+If you use [Claude Code](https://docs.anthropic.com/en/docs/claude-code), you can install the `/design-md` skill to browse and apply any style directly from your terminal.
+
+**Install:**
+
+```bash
+git clone https://github.com/VoltAgent/awesome-design-md.git
+cd awesome-design-md
+./install-skill.sh
+```
+
+Or manually copy the skill file:
+
+```bash
+mkdir -p ~/.claude/skills/design-md
+cp skills/claude-code/SKILL.md ~/.claude/skills/design-md/SKILL.md
+```
+
+**Usage in Claude Code:**
+
+```
+/design-md              # browse styles interactively
+/design-md vercel       # apply Vercel's design system
+/design-md stripe       # apply Stripe's design system
+```
+
+The skill fetches the DESIGN.md from [getdesign.md](https://getdesign.md) and saves it to your project root. Then just tell Claude to build UI using that design system.
+
 
 ## Contributing
 

--- a/install-skill.sh
+++ b/install-skill.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Install the awesome-design-md skill for Claude Code
+# This script copies the SKILL.md to your global Claude Code skills directory
+
+set -e
+
+SKILL_NAME="design-md"
+SKILL_DIR="$HOME/.claude/skills/$SKILL_NAME"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_SOURCE="$SCRIPT_DIR/skills/claude-code/SKILL.md"
+
+# Check if the source file exists
+if [ ! -f "$SKILL_SOURCE" ]; then
+  echo "Error: SKILL.md not found at $SKILL_SOURCE"
+  echo "Make sure you're running this script from the repo root."
+  exit 1
+fi
+
+# Create the skill directory
+mkdir -p "$SKILL_DIR"
+
+# Copy the skill file
+cp "$SKILL_SOURCE" "$SKILL_DIR/SKILL.md"
+
+echo "Installed '$SKILL_NAME' skill to $SKILL_DIR"
+echo ""
+echo "You can now use it in Claude Code:"
+echo "  /design-md          — browse and pick a style interactively"
+echo "  /design-md vercel   — apply a specific style directly"

--- a/skills/claude-code/SKILL.md
+++ b/skills/claude-code/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: design-md
+description: Apply a DESIGN.md style from the awesome-design-md collection to the current project. Use when the user wants to apply a website's design system, change UI style, or set up a DESIGN.md file.
+argument-hint: [style-name]
+---
+
+# Design.md Style Applier
+
+Apply a design system from the [awesome-design-md](https://github.com/VoltAgent/awesome-design-md) collection to the current project.
+
+## Usage
+
+- `/design-md <style-name>` — fetch and apply a specific style
+- `/design-md` — show available styles and let the user pick
+
+## Available Styles
+
+When no argument is provided, present the user with categories and styles to choose from using AskUserQuestion.
+
+### Style Catalog
+
+**AI & LLM Platforms:**
+claude, cohere, elevenlabs, minimax, mistral.ai, ollama, opencode.ai, replicate, runwayml, together.ai, voltagent, x.ai
+
+**Developer Tools & IDEs:**
+cursor, expo, lovable, raycast, superhuman, vercel, warp
+
+**Backend, Database & DevOps:**
+clickhouse, composio, hashicorp, mongodb, posthog, sanity, sentry, supabase
+
+**Productivity & SaaS:**
+cal, intercom, linear.app, mintlify, notion, resend, zapier
+
+**Design & Creative Tools:**
+airtable, clay, figma, framer, miro, webflow
+
+**Fintech & Crypto:**
+binance, coinbase, kraken, revolut, stripe, wise
+
+**E-commerce & Retail:**
+airbnb, meta, nike, shopify
+
+**Media & Consumer Tech:**
+apple, ibm, nvidia, pinterest, spacex, spotify, uber
+
+**Automotive:**
+bmw, ferrari, lamborghini, renault, tesla
+
+## Workflow
+
+1. If `$ARGUMENTS` is empty, use AskUserQuestion to let the user pick a category first, then a style within that category.
+2. If `$ARGUMENTS` is provided, use it as the style name directly.
+3. Fetch the DESIGN.md content from: `https://getdesign.md/$ARGUMENTS/design-md`
+   - Use the fetch MCP tool or WebFetch to get the raw markdown content from that page.
+   - The page contains the DESIGN.md content — extract the full markdown design system document from it.
+4. Save the content as `DESIGN.md` in the project root (current working directory).
+5. Tell the user the style has been applied and they can now reference it when building UI.
+
+## Important Notes
+
+- If the fetch fails, suggest the user visit the URL manually and copy the content.
+- Do NOT modify the fetched DESIGN.md content — apply it as-is.
+- If a DESIGN.md already exists in the project, ask the user before overwriting.


### PR DESCRIPTION
## Summary

- Adds a `/design-md` Claude Code skill that lets users browse and apply any DESIGN.md style interactively from their terminal
- Includes `install-skill.sh` for one-command installation to `~/.claude/skills/`
- Updates README with installation and usage instructions under the "How to Use" section

## How It Works

After running `./install-skill.sh`, users can type `/design-md` in Claude Code to:

1. **Browse interactively** — pick a category, then a style
2. **Apply directly** — e.g. `/design-md stripe` fetches and saves the Stripe DESIGN.md to the project root

The skill fetches content from [getdesign.md](https://getdesign.md) and writes it as `DESIGN.md` in the current project.

## Files Added

| File | Purpose |
|------|---------|
| `skills/claude-code/SKILL.md` | The skill definition file |
| `install-skill.sh` | One-command installer script |

## Test Plan

- [ ] Run `./install-skill.sh` and verify `~/.claude/skills/design-md/SKILL.md` is created
- [ ] Open Claude Code and run `/design-md` to verify interactive style selection
- [ ] Run `/design-md vercel` to verify direct style application
- [ ] Verify README renders correctly with the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)