### PR TITLE
[codex] add live getdesign catalog helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,28 @@ Each site includes:
 
 ### How to Use
 
+This repository is now a curated index. The live `DESIGN.md` files are fetched through the official `getdesign` CLI.
 
-1. Copy a site's `DESIGN.md` into your project root
-2. Tell your AI agent to use it.
+1. Browse all available design slugs:
+
+```bash
+npx getdesign@latest list
+```
+
+2. Download one `DESIGN.md` directly into your project:
+
+```bash
+npx getdesign@latest add vercel --out ./DESIGN.md
+```
+
+3. If you want a small searchable wrapper from this repo, use the helper script:
+
+```bash
+node scripts/getdesign-catalog.mjs search stripe
+node scripts/getdesign-catalog.mjs download stripe --dest ./DESIGN.md
+```
+
+4. Tell your AI agent to use the downloaded `DESIGN.md`.
 
 
 ## Contributing

--- a/scripts/getdesign-catalog.mjs
+++ b/scripts/getdesign-catalog.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+
+const slugPattern = /^[a-z0-9][a-z0-9.-]*$/;
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+function usage() {
+  process.stdout.write(
+    [
+      "Usage:",
+      "  node scripts/getdesign-catalog.mjs list",
+      "  node scripts/getdesign-catalog.mjs search <query>",
+      "  node scripts/getdesign-catalog.mjs download <slug> [--dest <path>] [--force]",
+      "",
+      "Notes:",
+      "  - Uses the official getdesign CLI via npx",
+      "  - Slugs come from the live getdesign catalog, not from files stored in this repo",
+    ].join("\n") + "\n"
+  );
+}
+
+function runGetdesign(args) {
+  const result = spawnSync("npx", ["getdesign@latest", ...args], {
+    encoding: "utf8",
+    shell: true,
+  });
+
+  if (result.error) {
+    throw new Error(`Failed to start npx: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const output = `${result.stdout || ""}${result.stderr || ""}`.trim();
+    throw new Error(output || "getdesign command failed.");
+  }
+  return `${result.stdout || ""}${result.stderr || ""}`.trim();
+}
+
+function parseCatalog(text) {
+  const entries = [];
+  const seen = new Set();
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line.includes(" - ")) {
+      continue;
+    }
+    const [slug, ...rest] = line.split(" - ");
+    const description = rest.join(" - ").trim();
+    if (!slugPattern.test(slug) || seen.has(slug)) {
+      continue;
+    }
+    seen.add(slug);
+    entries.push({ slug, description });
+  }
+
+  if (!entries.length) {
+    throw new Error("No catalog entries found in getdesign output.");
+  }
+
+  return entries;
+}
+
+function commandList() {
+  const entries = parseCatalog(runGetdesign(["list"]));
+  for (const entry of entries) {
+    process.stdout.write(`${entry.slug} - ${entry.description}\n`);
+  }
+}
+
+function commandSearch(args) {
+  const query = args.join(" ").trim();
+  if (!query) {
+    fail("Missing search query.");
+  }
+  const lowerQuery = query.toLowerCase();
+  const entries = parseCatalog(runGetdesign(["list"]));
+  const filtered = entries.filter(
+    (entry) =>
+      entry.slug.toLowerCase().includes(lowerQuery) ||
+      entry.description.toLowerCase().includes(lowerQuery)
+  );
+
+  if (!filtered.length) {
+    fail(`No matches for "${query}".`);
+  }
+
+  for (const entry of filtered) {
+    process.stdout.write(`${entry.slug} - ${entry.description}\n`);
+  }
+}
+
+function commandDownload(args) {
+  if (!args.length) {
+    fail("Missing slug.");
+  }
+
+  const slug = args[0].trim();
+  if (!slugPattern.test(slug)) {
+    fail(`Invalid slug: ${slug}`);
+  }
+
+  let destination = path.resolve(process.cwd(), "DESIGN.md");
+  let force = false;
+
+  for (let index = 1; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--dest") {
+      destination = path.resolve(args[index + 1] || "");
+      index += 1;
+      continue;
+    }
+    if (arg === "--force") {
+      force = true;
+      continue;
+    }
+  }
+
+  if (fs.existsSync(destination) && !force) {
+    fail(`Destination already exists: ${destination}`);
+  }
+
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  const getdesignArgs = ["add", slug, "--out", destination];
+  if (force) {
+    getdesignArgs.push("--force");
+  }
+  runGetdesign(getdesignArgs);
+  process.stdout.write(`Downloaded ${slug} to ${destination}\n`);
+}
+
+const [command, ...rest] = process.argv.slice(2);
+
+if (!command || command === "--help" || command === "-h") {
+  usage();
+  process.exit(command ? 0 : 1);
+}
+
+try {
+  if (command === "list") {
+    commandList();
+  } else if (command === "search") {
+    commandSearch(rest);
+  } else if (command === "download") {
+    commandDownload(rest);
+  } else {
+    usage();
+    process.exit(1);
+  }
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error));
+}


### PR DESCRIPTION
﻿## Summary

Adds a very small live-catalog helper for the current `getdesign` workflow:

- `node scripts/getdesign-catalog.mjs list`
- `node scripts/getdesign-catalog.mjs search <query>`
- `node scripts/getdesign-catalog.mjs download <slug> --dest ./DESIGN.md`
- updates the README "How to Use" section to match the live `getdesign` flow

Closes #374.

## Why

The need keeps resurfacing, but previous solutions were broader than necessary:
- #22 asked for CLI-friendly download commands
- #90 / #345 proposed embedding a skill in this repo
- #108 proposed a packaged interactive CLI

This PR takes the smallest useful path:
- no embedded skill
- no npm package setup
- no additional runtime dependencies
- no assumption that live `DESIGN.md` files still live directly in this repo

Instead, it wraps the official `npx getdesign@latest ...` flow with a tiny helper script and documents the current recommended usage in README.

## User impact

Users can now:
- discover valid slugs without guessing
- search styles by brand or description
- download a single `DESIGN.md` into a project with one command

## Validation

Ran locally:
- `node --check scripts/getdesign-catalog.mjs`
- `node scripts/getdesign-catalog.mjs search claude`
- `node scripts/getdesign-catalog.mjs download claude --dest <tempfile> --force`

## Related working prototype

A separate multi-client skill prototype also exists here:
- https://github.com/sank96/getdesign-catalog-skill

That prototype is intentionally **not** part of this PR because the maintainers previously signaled they do not want skills added to this repository.
