### PR TITLE
Add Material Design M3 Expressive DESIGN.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <div align="center">
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![DESIGN.md Count](https://img.shields.io/badge/DESIGN.md%20count-73-10b981?style=classic)
+![DESIGN.md Count](https://img.shields.io/badge/DESIGN.md%20count-74-10b981?style=classic)
 [![Last Update](https://img.shields.io/github/last-commit/VoltAgent/awesome-design-md?label=Last%20update&style=classic)](https://github.com/VoltAgent/awesome-design-md)
 [![Discord](https://img.shields.io/discord/1361559153780195478.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://s.voltagent.dev/discord)
 
@@ -103,6 +103,7 @@ Become a Sponsor [1M+ view] — your logo here and get listed on [getdesign.md](
 - [**Clay**](https://getdesign.md/clay/design-md) - Creative agency. Organic shapes, soft gradients, art-directed layout
 - [**Figma**](https://getdesign.md/figma/design-md) - Collaborative design tool. Vibrant multi-color, playful yet professional
 - [**Framer**](https://getdesign.md/framer/design-md) - Website builder. Bold black and blue, motion-first, design-forward
+- [**Material Design**](https://getdesign.md/material-design/design-md) - Google's design system. M3 Expressive evolution with adaptive color roles, tactile motion, and flexible rounded components
 - [**Miro**](https://getdesign.md/miro/design-md) - Visual collaboration. Bright yellow accent, infinite canvas aesthetic
 - [**Webflow**](https://getdesign.md/webflow/design-md) - Visual web builder. Blue-accented, polished marketing site aesthetic
 

--- a/design-md/material-design/DESIGN.md
+++ b/design-md/material-design/DESIGN.md
@@ -1,0 +1,535 @@
+---
+version: alpha
+name: Material-Design-M3-Expressive-inspired-design-analysis
+description: An inspired interpretation of Google's latest Material Design evolution, Material 3 Expressive — a dynamic, accessible design language built on adaptive color roles, high-contrast surfaces, flexible component shapes, and spring-based motion that makes interfaces feel personal, usable, and unmistakably Google.
+
+colors:
+  primary: "#6750A4"
+  on-primary: "#FFFFFF"
+  primary-container: "#EADDFF"
+  on-primary-container: "#21005D"
+  primary-fixed: "#EADDFF"
+  on-primary-fixed: "#21005D"
+  primary-fixed-dim: "#D0BCFF"
+  on-primary-fixed-variant: "#4F378B"
+  secondary: "#625B71"
+  on-secondary: "#FFFFFF"
+  secondary-container: "#E8DEF8"
+  on-secondary-container: "#1D192B"
+  tertiary: "#7D5260"
+  on-tertiary: "#FFFFFF"
+  tertiary-container: "#FFD8E4"
+  on-tertiary-container: "#31111D"
+  error: "#B3261E"
+  on-error: "#FFFFFF"
+  error-container: "#F9DEDC"
+  on-error-container: "#410E0B"
+  background: "#FFFBFE"
+  on-background: "#1C1B1F"
+  surface: "#FFFBFE"
+  on-surface: "#1C1B1F"
+  surface-dim: "#DED8E1"
+  surface-bright: "#FFFBFE"
+  surface-container-lowest: "#FFFFFF"
+  surface-container-low: "#F7F2FA"
+  surface-container: "#F3EDF7"
+  surface-container-high: "#ECE6F0"
+  surface-container-highest: "#E6E0E9"
+  surface-variant: "#E7E0EC"
+  on-surface-variant: "#49454F"
+  outline: "#79747E"
+  outline-variant: "#CAC4D0"
+  inverse-surface: "#313033"
+  inverse-on-surface: "#F4EFF4"
+  inverse-primary: "#D0BCFF"
+  shadow: "#000000"
+  scrim: "#000000"
+  expressive-blue: "#4285F4"
+  expressive-green: "#34A853"
+  expressive-yellow: "#FBBC04"
+  expressive-red: "#EA4335"
+  expressive-lilac: "#D0BCFF"
+  expressive-sky: "#D9E2FF"
+  dark-primary: "#D0BCFF"
+  dark-on-primary: "#381E72"
+  dark-primary-container: "#4F378B"
+  dark-on-primary-container: "#EADDFF"
+  dark-secondary: "#CCC2DC"
+  dark-on-secondary: "#332D41"
+  dark-secondary-container: "#4A4458"
+  dark-on-secondary-container: "#E8DEF8"
+  dark-tertiary: "#EFB8C8"
+  dark-on-tertiary: "#492532"
+  dark-tertiary-container: "#633B48"
+  dark-on-tertiary-container: "#FFD8E4"
+  dark-background: "#1C1B1F"
+  dark-on-background: "#E6E1E5"
+  dark-surface: "#1C1B1F"
+  dark-on-surface: "#E6E1E5"
+  dark-surface-container: "#211F26"
+  dark-surface-container-high: "#2B2930"
+  dark-surface-variant: "#49454F"
+  dark-on-surface-variant: "#CAC4D0"
+  dark-outline: "#938F99"
+
+typography:
+  display-large:
+    fontFamily: "Google Sans, Roboto, system-ui, -apple-system, BlinkMacSystemFont, sans-serif"
+    fontSize: 57px
+    fontWeight: 400
+    lineHeight: 64px
+    letterSpacing: -0.25px
+  display-medium:
+    fontFamily: "Google Sans, Roboto, system-ui, -apple-system, BlinkMacSystemFont, sans-serif"
+    fontSize: 45px
+    fontWeight: 400
+    lineHeight: 52px
+    letterSpacing: 0
+  display-small:
+    fontFamily: "Google Sans, Roboto, system-ui, -apple-system, BlinkMacSystemFont, sans-serif"
+    fontSize: 36px
+    fontWeight: 400
+    lineHeight: 44px
+    letterSpacing: 0
+  headline-large:
+    fontFamily: "Google Sans, Roboto, system-ui, -apple-system, sans-serif"
+    fontSize: 32px
+    fontWeight: 400
+    lineHeight: 40px
+    letterSpacing: 0
+  headline-medium:
+    fontFamily: "Google Sans, Roboto, system-ui, -apple-system, sans-serif"
+    fontSize: 28px
+    fontWeight: 400
+    lineHeight: 36px
+    letterSpacing: 0
+  headline-small:
+    fontFamily: "Google Sans, Roboto, system-ui, -apple-system, sans-serif"
+    fontSize: 24px
+    fontWeight: 400
+    lineHeight: 32px
+    letterSpacing: 0
+  title-large:
+    fontFamily: "Google Sans, Roboto, system-ui, -apple-system, sans-serif"
+    fontSize: 22px
+    fontWeight: 400
+    lineHeight: 28px
+    letterSpacing: 0
+  title-medium:
+    fontFamily: "Roboto, Google Sans, system-ui, -apple-system, sans-serif"
+    fontSize: 16px
+    fontWeight: 500
+    lineHeight: 24px
+    letterSpacing: 0.15px
+  title-small:
+    fontFamily: "Roboto, Google Sans, system-ui, -apple-system, sans-serif"
+    fontSize: 14px
+    fontWeight: 500
+    lineHeight: 20px
+    letterSpacing: 0.1px
+  body-large:
+    fontFamily: "Roboto, Google Sans, system-ui, -apple-system, sans-serif"
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 24px
+    letterSpacing: 0.5px
+  body-medium:
+    fontFamily: "Roboto, Google Sans, system-ui, -apple-system, sans-serif"
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 20px
+    letterSpacing: 0.25px
+  body-small:
+    fontFamily: "Roboto, Google Sans, system-ui, -apple-system, sans-serif"
+    fontSize: 12px
+    fontWeight: 400
+    lineHeight: 16px
+    letterSpacing: 0.4px
+  label-large:
+    fontFamily: "Roboto, Google Sans, system-ui, -apple-system, sans-serif"
+    fontSize: 14px
+    fontWeight: 500
+    lineHeight: 20px
+    letterSpacing: 0.1px
+  label-medium:
+    fontFamily: "Roboto, Google Sans, system-ui, -apple-system, sans-serif"
+    fontSize: 12px
+    fontWeight: 500
+    lineHeight: 16px
+    letterSpacing: 0.5px
+  label-small:
+    fontFamily: "Roboto, Google Sans, system-ui, -apple-system, sans-serif"
+    fontSize: 11px
+    fontWeight: 500
+    lineHeight: 16px
+    letterSpacing: 0.5px
+
+rounded:
+  none: 0px
+  extra-small: 4px
+  small: 8px
+  medium: 12px
+  large: 16px
+  large-increased: 20px
+  extra-large: 28px
+  extra-large-increased: 32px
+  extra-large-top: 28px 28px 0 0
+  full: 9999px
+
+spacing:
+  xxs: 4px
+  xs: 8px
+  sm: 12px
+  md: 16px
+  lg: 24px
+  xl: 32px
+  xxl: 40px
+  section: 64px
+  page: 96px
+
+motion:
+  emphasized: "cubic-bezier(0.2, 0, 0, 1)"
+  emphasized-accelerate: "cubic-bezier(0.3, 0, 0.8, 0.15)"
+  emphasized-decelerate: "cubic-bezier(0.05, 0.7, 0.1, 1)"
+  standard: "cubic-bezier(0.2, 0, 0, 1)"
+  standard-accelerate: "cubic-bezier(0.3, 0, 1, 1)"
+  standard-decelerate: "cubic-bezier(0, 0, 0, 1)"
+  spring-expressive: "duration 500ms; damping 0.75; response 0.35s"
+  duration-short: 150ms
+  duration-medium: 300ms
+  duration-long: 500ms
+
+components:
+  button-filled:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.label-large}"
+    rounded: "{rounded.full}"
+    minHeight: 40px
+    padding: 10px 24px
+    stateLayer: "on-primary at 8% hover, 10% focus, 10% pressed"
+  button-filled-tonal:
+    backgroundColor: "{colors.secondary-container}"
+    textColor: "{colors.on-secondary-container}"
+    typography: "{typography.label-large}"
+    rounded: "{rounded.full}"
+    minHeight: 40px
+    padding: 10px 24px
+  button-expressive-large:
+    backgroundColor: "{colors.primary-container}"
+    textColor: "{colors.on-primary-container}"
+    typography: "{typography.title-medium}"
+    rounded: "{rounded.extra-large}"
+    minHeight: 56px
+    padding: 16px 28px
+    motion: "spring-expressive scale and shape morph on press"
+  button-outlined:
+    backgroundColor: "transparent"
+    textColor: "{colors.primary}"
+    borderColor: "{colors.outline}"
+    borderWidth: 1px
+    typography: "{typography.label-large}"
+    rounded: "{rounded.full}"
+    minHeight: 40px
+    padding: 10px 24px
+  button-text:
+    backgroundColor: "transparent"
+    textColor: "{colors.primary}"
+    typography: "{typography.label-large}"
+    rounded: "{rounded.full}"
+    minHeight: 40px
+    padding: 10px 12px
+  fab-primary:
+    backgroundColor: "{colors.primary-container}"
+    textColor: "{colors.on-primary-container}"
+    rounded: "{rounded.large}"
+    width: 56px
+    height: 56px
+    elevation: "level-3"
+  fab-large-expressive:
+    backgroundColor: "{colors.tertiary-container}"
+    textColor: "{colors.on-tertiary-container}"
+    rounded: "{rounded.extra-large}"
+    width: 96px
+    height: 96px
+    elevation: "level-3"
+    motion: "container grows from icon anchor with emphasized deceleration"
+  card-filled:
+    backgroundColor: "{colors.surface-container-highest}"
+    textColor: "{colors.on-surface}"
+    typography: "{typography.body-medium}"
+    rounded: "{rounded.medium}"
+    padding: 16px
+  card-elevated:
+    backgroundColor: "{colors.surface-container-low}"
+    textColor: "{colors.on-surface}"
+    typography: "{typography.body-medium}"
+    rounded: "{rounded.medium}"
+    padding: 16px
+    elevation: "level-1"
+  card-outlined:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.on-surface}"
+    borderColor: "{colors.outline-variant}"
+    borderWidth: 1px
+    rounded: "{rounded.medium}"
+    padding: 16px
+  chip-assist:
+    backgroundColor: "transparent"
+    textColor: "{colors.on-surface}"
+    borderColor: "{colors.outline}"
+    typography: "{typography.label-large}"
+    rounded: "{rounded.small}"
+    minHeight: 32px
+    padding: 6px 16px
+  chip-filter-selected:
+    backgroundColor: "{colors.secondary-container}"
+    textColor: "{colors.on-secondary-container}"
+    typography: "{typography.label-large}"
+    rounded: "{rounded.small}"
+    minHeight: 32px
+    padding: 6px 16px
+  text-field-filled:
+    backgroundColor: "{colors.surface-container-highest}"
+    textColor: "{colors.on-surface}"
+    labelColor: "{colors.on-surface-variant}"
+    activeIndicator: "{colors.primary}"
+    rounded: "{rounded.extra-small} {rounded.extra-small} 0 0"
+    minHeight: 56px
+    padding: 8px 16px
+  text-field-outlined:
+    backgroundColor: "transparent"
+    textColor: "{colors.on-surface}"
+    labelColor: "{colors.on-surface-variant}"
+    borderColor: "{colors.outline}"
+    activeBorderColor: "{colors.primary}"
+    rounded: "{rounded.extra-small}"
+    minHeight: 56px
+    padding: 8px 16px
+  top-app-bar:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.on-surface}"
+    typography: "{typography.title-large}"
+    height: 64px
+    padding: 0 16px
+  expressive-toolbar:
+    backgroundColor: "{colors.surface-container}"
+    textColor: "{colors.on-surface}"
+    typography: "{typography.title-medium}"
+    rounded: "{rounded.full}"
+    minHeight: 64px
+    padding: 8px 12px
+    motion: "items expand, compress, and reorder with spatial continuity"
+  navigation-bar:
+    backgroundColor: "{colors.surface-container}"
+    textColor: "{colors.on-surface-variant}"
+    selectedTextColor: "{colors.on-secondary-container}"
+    selectedIndicatorColor: "{colors.secondary-container}"
+    typography: "{typography.label-medium}"
+    height: 80px
+  navigation-rail:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.on-surface-variant}"
+    selectedIndicatorColor: "{colors.secondary-container}"
+    width: 80px
+  dialog:
+    backgroundColor: "{colors.surface-container-high}"
+    textColor: "{colors.on-surface}"
+    typography: "{typography.body-medium}"
+    rounded: "{rounded.extra-large}"
+    padding: 24px
+    elevation: "level-3"
+  bottom-sheet:
+    backgroundColor: "{colors.surface-container-low}"
+    textColor: "{colors.on-surface}"
+    rounded: "{rounded.extra-large-top}"
+    padding: 24px
+    dragHandleColor: "{colors.on-surface-variant}"
+  carousel-card:
+    backgroundColor: "{colors.surface-container}"
+    textColor: "{colors.on-surface}"
+    rounded: "{rounded.extra-large}"
+    padding: 24px
+    motion: "peek, snap, and scale cards with emphasized easing"
+
+elevation:
+  level-0: "none"
+  level-1: "0 1px 2px rgba(0,0,0,0.30), 0 1px 3px 1px rgba(0,0,0,0.15)"
+  level-2: "0 1px 2px rgba(0,0,0,0.30), 0 2px 6px 2px rgba(0,0,0,0.15)"
+  level-3: "0 4px 8px 3px rgba(0,0,0,0.15), 0 1px 3px rgba(0,0,0,0.30)"
+  level-4: "0 6px 10px 4px rgba(0,0,0,0.15), 0 2px 3px rgba(0,0,0,0.30)"
+  level-5: "0 8px 12px 6px rgba(0,0,0,0.15), 0 4px 4px rgba(0,0,0,0.30)"
+---
+
+# Material Design M3 Expressive — DESIGN.md
+
+## 1. Visual Theme & Atmosphere
+
+Material Design's latest evolution, Material 3 Expressive, keeps the familiar Google foundation — clear hierarchy, accessible color roles, predictable components — and turns up personality through more varied shapes, richer surfaces, and playful motion. The interface should feel helpful, adaptive, and emotionally responsive without becoming ornamental.
+
+Use this system when you want an app to feel:
+
+- **Google-native and trustworthy** — semantic color roles, measured type, strong accessibility defaults.
+- **Expressive but systematic** — dynamic palettes and flexible shapes that still map to clear component rules.
+- **Touchable and spatial** — large hit targets, rounded containers, clear state layers, and transitions that preserve object continuity.
+- **Personalized** — color can derive from user content or brand input while preserving contrast.
+
+The baseline is clean and light: warm off-white surfaces, purple primary actions, lavender containers, low elevation, and carefully layered surface containers. Add expressiveness through selected hero areas, oversized FABs, tonal panels, varied corner radii, and springy transitions.
+
+## 2. Color Palette & Roles
+
+Use Material color roles instead of hard-coded decorative colors. Components should reference `primary`, `surface`, `surface-container`, `on-surface`, and related semantic roles so light and dark themes can swap safely.
+
+### Core roles
+
+| Role | Token | Usage |
+|---|---|---|
+| Primary | `#6750A4` | Main actions, active controls, selected indicators |
+| Primary container | `#EADDFF` | Tonal CTA backgrounds, hero highlights, selected surfaces |
+| Secondary container | `#E8DEF8` | Chips, navigation indicators, lower-emphasis actions |
+| Tertiary container | `#FFD8E4` | Expressive supporting panels, feature callouts |
+| Surface | `#FFFBFE` | Page background and base app surface |
+| Surface container | `#F3EDF7` | Cards, bars, grouped controls, tonal panels |
+| Outline | `#79747E` | Outlined controls and dividers |
+| Error | `#B3261E` | Destructive and validation states only |
+
+### Expressive accents
+
+Google's expressive accent set can be used sparingly in illustrations, education moments, or onboarding panels: blue `#4285F4`, green `#34A853`, yellow `#FBBC04`, red `#EA4335`, and lilac `#D0BCFF`. Do not turn these into random rainbow chrome; keep product controls semantic.
+
+### Dark mode
+
+Dark mode is not pure black. Use `dark-background #1C1B1F`, `dark-surface-container #211F26`, and lavender `dark-primary #D0BCFF`. Keep elevation visible with tonal surface shifts before using heavy shadows.
+
+## 3. Typography Rules
+
+Material uses a type scale more than a single visual trick. Use Google Sans for brand and app-chrome headings when available, Roboto for dense app UI and body text, and system fallbacks everywhere.
+
+| Style | Size / line | Weight | Use |
+|---|---:|---:|---|
+| Display large | 57 / 64 | 400 | Marketing hero, empty-state statement |
+| Display medium | 45 / 52 | 400 | Feature intro, large panel title |
+| Display small | 36 / 44 | 400 | Page hero title on tablet/desktop |
+| Headline large | 32 / 40 | 400 | Screen title |
+| Headline medium | 28 / 36 | 400 | Section title |
+| Headline small | 24 / 32 | 400 | Card cluster title |
+| Title large | 22 / 28 | 400 | App bar title |
+| Title medium | 16 / 24 | 500 | List item title, dialog title support |
+| Body large | 16 / 24 | 400 | Primary reading text |
+| Body medium | 14 / 20 | 400 | Dense UI copy |
+| Label large | 14 / 20 | 500 | Buttons and chips |
+
+Avoid ultra-tight tracking except in large display sizes. Let line height create readability, and use weight 500 for controls rather than heavy bolding.
+
+## 4. Component Stylings
+
+### Buttons
+
+- Use pill-shaped filled buttons for the most important action.
+- Use filled tonal buttons when the page already has strong color or when a secondary action should still feel tappable.
+- Use outlined buttons for medium emphasis and text buttons for inline actions.
+- Expressive large buttons can use 56px height, extra-large corners, and subtle shape morph on press.
+
+### FABs
+
+Floating action buttons are high-emphasis. In M3 Expressive, a FAB may become larger and more characterful, but it should still anchor one primary creation action. Use primary or tertiary containers rather than saturated primary fills for better harmony.
+
+### Cards
+
+Use filled cards for content groups, elevated cards only when they float over similar surfaces, and outlined cards when comparison or selection is important. Expressive cards can use asymmetric layouts, image masks, or extra-large corners, but their internal spacing should remain regular.
+
+### Navigation
+
+Navigation bars and rails use a selected pill indicator. Keep labels short. Selected states should use container color, not only icon color. On large screens, prefer navigation rail or drawer to preserve app structure.
+
+### Text fields
+
+Filled text fields sit on `surface-container-highest`; outlined text fields use `outline`. Focus state should switch active indicator or border to `primary`. Labels float clearly; error state uses `error` and `on-error-container`.
+
+### Toolbars
+
+Toolbars can be rounded containers with grouped actions. Expressive toolbars should feel tactile: icons may expand into labels, selected groups can grow, and secondary actions can collapse into overflow while maintaining spatial continuity.
+
+## 5. Layout Principles
+
+- Base spacing follows a 4px grid with 8, 12, 16, 24, 32, 40, 64, and 96px steps.
+- Keep page margins generous: 16px mobile, 24–32px tablet, 40–64px desktop.
+- Use surface containers to group related content instead of drawing many divider lines.
+- Touch targets must be at least 48x48px even when visual icons are smaller.
+- Prefer adaptive panes on larger screens: navigation rail + list + detail rather than stretched mobile cards.
+
+### Expressive composition
+
+Material 3 Expressive can vary rhythm: pair a large rounded hero panel with smaller utility cards, or a prominent FAB with quiet navigation. Variation should clarify priority. Avoid making every element oversized or animated.
+
+## 6. Depth & Elevation
+
+Material depth is subtle and functional. Start with tonal elevation (`surface-container-low` through `surface-container-highest`) before adding shadow. Reserve level-3+ elevation for FABs, menus, dialogs, and modal surfaces.
+
+State layers replace many bespoke hover colors:
+
+- Hover: on-color overlay around 8%
+- Focus: on-color overlay around 10–12%
+- Pressed: on-color overlay around 10–12%
+- Dragged: stronger overlay plus elevation lift
+
+## 7. Motion & Interaction
+
+Motion should explain where things came from and where they went. Use emphasized easing for route changes, container transforms, dialogs, and FAB expansion. Use shorter standard easing for simple fades and color changes.
+
+Expressive motion can feel springy, but it should not feel chaotic:
+
+- Use scale and shape morph for pressed controls.
+- Use shared-axis or container transform for navigation between related surfaces.
+- Use small bounce/spring only for high-delight moments such as completion, creation, or mode switches.
+- Respect reduced-motion settings by replacing spatial motion with fades.
+
+## 8. Do's and Don'ts
+
+### Do
+
+- Use semantic color roles and `on-*` roles for text contrast.
+- Keep primary actions obvious and reachable.
+- Combine tonal surfaces, rounded geometry, and motion for expression.
+- Use dynamic color when personalization is desired, but test contrast.
+- Maintain a predictable type scale and component hierarchy.
+
+### Don't
+
+- Do not hard-code random accent colors into core controls.
+- Do not use pure black dark mode unless the product explicitly needs OLED black.
+- Do not animate every state change; reserve expressive motion for meaningful transitions.
+- Do not flatten all surfaces into the same background.
+- Do not reduce touch targets below 48px to make layouts denser.
+
+## 9. Responsive Behavior
+
+| Breakpoint | Behavior |
+|---|---|
+| Mobile `< 600px` | Single column, bottom navigation, 16px margins, large touch targets |
+| Tablet `600–839px` | Navigation rail, two-column content where useful, 24px margins |
+| Desktop `>= 840px` | Rail or drawer, multi-pane layouts, 40px+ margins, larger hero panels |
+| Expanded `>= 1200px` | Center max-width content, avoid over-stretched cards, use adaptive panes |
+
+Dialogs become full-screen or bottom sheets on compact screens. Cards stack vertically on mobile but can become masonry-like or split-pane on larger screens if reading order remains clear.
+
+## 10. Agent Prompt Guide
+
+When generating UI with this design system, tell the agent:
+
+> Build this screen using Material 3 Expressive. Use semantic Material color roles, warm off-white surfaces, lavender tonal containers, Google Sans/Roboto typography, 48px touch targets, rounded components, selected pill indicators, and subtle emphasized motion. Make the layout feel Google-native, accessible, tactile, and a little more expressive than standard Material 3.
+
+Quick references:
+
+- Primary action: `primary #6750A4` on `on-primary #FFFFFF`
+- Tonal action: `primary-container #EADDFF` on `on-primary-container #21005D`
+- Page background: `surface #FFFBFE`
+- Grouped panels: `surface-container #F3EDF7`
+- Text: `on-surface #1C1B1F`
+- Muted text: `on-surface-variant #49454F`
+- Corner language: pill buttons, 12px cards, 28px dialogs/sheets, larger expressive panels
+- Motion: emphasized easing, container transforms, restrained spring on meaningful interactions
+
+## Source Notes
+
+This file is based on the public Material Design / Material 3 guidance and the official Material Design Atom feed entries for Material 3 Expressive, including “Start building with Material 3 Expressive” and the follow-up motion-theming article.

--- a/design-md/material-design/README.md
+++ b/design-md/material-design/README.md
@@ -1,0 +1,5 @@
+# Material Design Inspired Design System Analysis
+
+Design system details have been moved to: https://getdesign.md/material-design/design-md
+
+You can also view previews, dark mode examples, and download options on getdesign.md.


### PR DESCRIPTION
## Summary

- Adds a new `design-md/material-design/` entry for Google's Material Design, focused on the latest Material 3 Expressive evolution.
- Includes a full `DESIGN.md` with Material color roles, typography scale, shape, spacing, elevation, components, responsive behavior, and agent prompt guidance.
- Updates the root README collection and DESIGN.md count badge.

## Source / recency check

Checked the official Material Design Atom feed (`https://material.io/feed.xml`). The latest entries are:

- `2025-05-20` — “Adding Motion Physics with Jetpack Compose”
- `2025-05-13` — “Start building with Material 3 Expressive”

The added design file is based on public Material Design / Material 3 guidance and these Material 3 Expressive release entries.

## Validation

- `git diff --check`
- Verified new `DESIGN.md` frontmatter and expected sections exist.
