### PR TITLE
fix: correct README badge count from 73 to 71

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <div align="center">
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![DESIGN.md Count](https://img.shields.io/badge/DESIGN.md%20count-73-10b981?style=classic)
+![DESIGN.md Count](https://img.shields.io/badge/DESIGN.md%20count-71-10b981?style=classic)
 [![Last Update](https://img.shields.io/github/last-commit/VoltAgent/awesome-design-md?label=Last%20update&style=classic)](https://github.com/VoltAgent/awesome-design-md)
 [![Discord](https://img.shields.io/discord/1361559153780195478.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://s.voltagent.dev/discord)
 


### PR DESCRIPTION
## Summary

- Corrected the README.md shield badge from 73 to 71 DESIGN.md entries.
- The actual entry count is 71 (verified with 71).

## Problem

The badge showed 73 but there are 71 design-md directories. This is a mechanical inaccuracy — no design content was changed.

## Solution

Single-line change in README.md replacing 73 with 71 in the shields.io URL.

## Tests

71

## Risk / Compatibility

- Documentation only change.
- No code, no API, no runtime behavior affected.
- No new dependencies.