### PR TITLE
docs: index Slack design entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <div align="center">
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![DESIGN.md Count](https://img.shields.io/badge/DESIGN.md%20count-73-10b981?style=classic)
+![DESIGN.md Count](https://img.shields.io/badge/DESIGN.md%20count-74-10b981?style=classic)
 [![Last Update](https://img.shields.io/github/last-commit/VoltAgent/awesome-design-md?label=Last%20update&style=classic)](https://github.com/VoltAgent/awesome-design-md)
 [![Discord](https://img.shields.io/discord/1361559153780195478.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://s.voltagent.dev/discord)
 
@@ -131,6 +131,7 @@ Tools, platforms, and services for designing and shipping web apps with AI.
 - [**Mintlify**](https://getdesign.md/mintlify/design-md) - Documentation platform. Clean, green-accented, reading-optimized
 - [**Notion**](https://getdesign.md/notion/design-md) - All-in-one workspace. Warm minimalism, serif headings, soft surfaces
 - [**Resend**](https://getdesign.md/resend/design-md) - Email API for developers. Minimal dark theme, monospace accents
+- [**Slack**](https://getdesign.md/slack/design-md) - Workplace messaging. Deep aubergine primary, cream-lavender hero gradients, blue inline links, and pill CTAs
 - [**Zapier**](https://getdesign.md/zapier/design-md) - Automation platform. Warm orange, friendly illustration-driven
 
 ### Design & Creative Tools

--- a/design-md/slack/DESIGN.md
+++ b/design-md/slack/DESIGN.md
@@ -1,7 +1,7 @@
 ---
 version: alpha
-name: Slacc-Inspired-design-analysis
-description: An inspired interpretation of Slacc's design language — a workplace messaging brand built on a deep aubergine primary, with cream-lavender hero gradients, blue inline links, and pill CTAs. The system pairs a proprietary humanist sans for display with a separate utility sans for body, and stages product UI mockups inside soft pastel-mesh hero composites that act as both decoration and feature explanation.
+name: Slack-Inspired-design-analysis
+description: An inspired interpretation of Slack's design language — a workplace messaging brand built on a deep aubergine primary, with cream-lavender hero gradients, blue inline links, and pill CTAs. The system pairs a proprietary humanist sans for display with a separate utility sans for body, and stages product UI mockups inside soft pastel-mesh hero composites that act as both decoration and feature explanation.
 
 colors:
   primary: "#4a154b"

--- a/design-md/slack/README.md
+++ b/design-md/slack/README.md
@@ -1,0 +1,5 @@
+# Slack Inspired Design System Analysis
+
+Design system details have been moved to: https://getdesign.md/slack/design-md
+
+You can also view previews, dark mode examples, and download options on getdesign.md.


### PR DESCRIPTION
## Summary
- Add Slack to the root collection index.
- Update the DESIGN.md count badge from 73 to 74.
- Add the missing `design-md/slack/README.md` redirect file.
- Fix the Slack frontmatter typo from `Slacc` to `Slack`.

## Motivation
The repository already includes `design-md/slack/DESIGN.md`, but Slack was missing from the root README collection, the count badge still said 73, and the Slack directory did not have the standard per-design README redirect. This keeps the index metadata aligned with the shipped design files.

## Verification
- Ran `git diff --check`.
- Checked that there are 74 `design-md/*/DESIGN.md` files.
- Checked every design slug has a root README getdesign.md link and a per-directory README.
- Checked Slack appears in the root README and the frontmatter uses `Slack`.

## Risk
Docs-only/index-only change. No design tokens or runtime code are changed.