### PR TITLE
docs: fix collection drift and contribution policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,14 +11,11 @@ This repository is a curated collection of DESIGN.md files extracted from popula
 If you notice issues with an existing file:
 
 1. **Open an issue first** to describe what you'd like to change and get feedback from maintainers
-2. Open the site's `DESIGN.md`
-3. Compare against the live site
-4. Fix incorrect hex values, missing tokens, or weak descriptions
-5. Update the `preview.html` and `preview-dark.html` if your changes affect displayed tokens
-6. Open a PR with before/after rationale
+2. Reference the affected site's `DESIGN.md`
+3. Compare it against the live site
+4. Describe the incorrect hex values, missing tokens, or weak descriptions you found
 
-
-We cannot accept DESIGN.md pull requests to maintain the quality of the existing collection.
+To maintain the quality and consistency of the collection, fixes are applied by maintainers based on accepted issues. Please report problems through issues rather than opening DESIGN.md pull requests.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <div align="center">
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![DESIGN.md Count](https://img.shields.io/badge/DESIGN.md%20count-73-10b981?style=classic)
+![DESIGN.md Count](https://img.shields.io/badge/DESIGN.md%20count-74-10b981?style=classic)
 [![Last Update](https://img.shields.io/github/last-commit/VoltAgent/awesome-design-md?label=Last%20update&style=classic)](https://github.com/VoltAgent/awesome-design-md)
 [![Discord](https://img.shields.io/discord/1361559153780195478.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://s.voltagent.dev/discord)
 
@@ -129,6 +129,7 @@ You can [request a DESIGN.md](https://getdesign.md/request) for specific website
 - [**Mintlify**](https://getdesign.md/mintlify/design-md) - Documentation platform. Clean, green-accented, reading-optimized
 - [**Notion**](https://getdesign.md/notion/design-md) - All-in-one workspace. Warm minimalism, serif headings, soft surfaces
 - [**Resend**](https://getdesign.md/resend/design-md) - Email API for developers. Minimal dark theme, monospace accents
+- [**Slack**](https://getdesign.md/slack/design-md) - Team communication platform. Deep aubergine primary, cream-lavender hero gradients, pill CTAs
 - [**Zapier**](https://getdesign.md/zapier/design-md) - Automation platform. Warm orange, friendly illustration-driven
 
 ### Design & Creative Tools
@@ -207,13 +208,14 @@ Every file follows the [Stitch DESIGN.md format](https://stitch.withgoogle.com/d
 | 8 | Responsive Behavior | Breakpoints, touch targets, collapsing strategy |
 | 9 | Agent Prompt Guide | Quick color reference, ready-to-use prompts |
 
-Each site includes:
+Each site folder includes:
 
 | File | Purpose |
 |------|---------|
 | `DESIGN.md` | The design system (what agents read) |
-| `preview.html` | Visual catalog showing color swatches, type scale, buttons, cards |
-| `preview-dark.html` | Same catalog with dark surfaces |
+| `README.md` | Quick overview with a link to previews and downloads on getdesign.md |
+
+Interactive previews (light/dark color swatches, type scale, buttons, cards) are available for every site on [getdesign.md](https://getdesign.md).
 
 ### How to Use
 

--- a/design-md/slack/README.md
+++ b/design-md/slack/README.md
@@ -1,0 +1,5 @@
+# Slack Inspired Design System Analysis
+
+Design system details have been moved to: https://getdesign.md/slack/design-md
+
+You can also view previews, dark mode examples, and download options on getdesign.md.


### PR DESCRIPTION
## Summary

This PR addresses small documentation and metadata inconsistencies found while auditing the repo. All changes are docs/metadata only — no DESIGN.md token content is modified.

## Changes
- **Add missing Slack entry** to the README collection list (the `design-md/slack` folder existed but was not listed).
- **Update DESIGN.md count badge** from 73 → 74 to match the actual number of site folders.
- **Add `design-md/slack/README.md`** so the folder matches the convention used by every other site.
- **Correct the "Each site includes" table** — it referenced `preview.html`/`preview-dark.html` files that do not exist in the repo; previews live on getdesign.md.
- **Resolve contradictory contribution instructions** in CONTRIBUTING.md (it told contributors to open a PR while also saying DESIGN.md PRs are not accepted).

## Why
These were small but cumulative inconsistencies between the docs, the badge count, and the actual folder contents that could erode trust in the curation quality.

## Notes
Per the contribution guidelines, fixes are normally maintainer-applied via issues. Opening this as a PR for review since it is limited to documentation/metadata corrections — happy to convert to an issue if preferred.